### PR TITLE
Add Ollama llama3.2b local backend

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ The system is designed for research, production-grade AI pipelines, and responsi
 * **Knowledge Graph Extraction**: Entities and relations rendered as a dynamic graph
 * **Reference Fusion**: Combines vectorstore retrieval with real-time web search
 * **User Interaction Layer**: Supports clarifications, feedback, and follow-up queries
-* **Dynamic Backend Selection**: Supports Groq (LLaMA 3), OpenAI (GPT-4), and Ollama for local inference
+* **Dynamic Backend Selection**: Supports Groq (LLaMA 3), OpenAI (GPT-4), and Ollama for local inference (e.g., Llama3.2b)
 
 ---
 
@@ -113,7 +113,7 @@ python3 -m venv .venv
 source .venv/bin/activate  # or .venv\Scripts\activate.bat on Windows
 pip install -r requirements.txt
 ```
-Set your provider keys in `.env` (`OPENAI_API_KEY`, `GROQ_API_KEY`) or export them in the shell.
+Set your provider keys in `.env` (`OPENAI_API_KEY`, `GROQ_API_KEY`) or set `LLM_PROVIDER=ollama` for local models. Customize `OLLAMA_BASE_URL` and `OLLAMA_MODEL` if needed.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -238,3 +238,4 @@ xxhash==3.5.0
 yarl==1.20.0
 zipp==3.21.0
 zstandard==0.23.0
+ollama==0.5.1

--- a/sample_.env.txt
+++ b/sample_.env.txt
@@ -1,6 +1,6 @@
 .env
 
-# LLM Provider (groq or openai)
+# LLM Provider (Groq, OpenAI, or Ollama)
 LLM_PROVIDER=openai
 
 # Groq API details
@@ -8,6 +8,10 @@ GROQ_API_KEY=key
 
 # OpenAI API details (for later switch)
 OPENAI_API_KEY=key
+
+# Ollama local settings
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=llama3.2b
 
 USE_32K_CONTEXT=true
 
@@ -27,3 +31,4 @@ OFFICE_DIRECTORY="/Users/deepaksaipendyala/Documents/MultiAgent/resources"
 # WEB_URLS=["https://arxiv.org/abs/2305.12345", "https://arxiv.org/html/2402.03367v2","https://arxiv.org/html/2402.13547v2", "https://medium.com/@kiran.phd.0102/rag-fusion-revolution-a-paradigm-shift-in-generative-ai-2349b9f81c66"]
 # WEB_URLS=["https://medium.com/@kiran.phd.0102/rag-fusion-revolution-a-paradigm-shift-in-generative-ai-2349b9f81c66"]
 WEB_URLS=[]
+

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,6 +13,8 @@ class Settings(BaseSettings):
     LLM_PROVIDER: str
     GROQ_API_KEY: str
     OPENAI_API_KEY: str
+    OLLAMA_BASE_URL: str = "http://localhost:11434"
+    OLLAMA_MODEL: str = "llama3.2b"
 
     # Embedding settings
     EMBEDDING_PROVIDER: str

--- a/utils/llm.py
+++ b/utils/llm.py
@@ -1,11 +1,12 @@
 # utils/llm.py
 
 from langchain_openai import ChatOpenAI
+from langchain_community.chat_models import ChatOllama
 from utils.config import settings
 
 def get_llm():
     """
-    Dynamically select the LLM provider (Groq or OpenAI) based on the config settings.
+    Dynamically select the LLM provider (Groq, OpenAI, or Ollama) based on the config settings.
     Returns a LangChain-compatible LLM object, optionally with a 32 K context window.
     """
     provider = settings.LLM_PROVIDER.lower()
@@ -39,6 +40,14 @@ def get_llm():
             temperature=0.2,
             streaming=True,
             max_tokens=max_toks
+        )
+
+    elif provider == "ollama":
+        return ChatOllama(
+            base_url=settings.OLLAMA_BASE_URL,
+            model=settings.OLLAMA_MODEL,
+            temperature=0.2,
+            streaming=True
         )
 
     else:


### PR DESCRIPTION
## Summary
- enable Ollama backend via `ChatOllama`
- add `OLLAMA_BASE_URL` and `OLLAMA_MODEL` configuration
- show example Ollama settings in sample env
- document how to run with local Ollama
- require `ollama` package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a9d90ed8832281e34da0627f6bea